### PR TITLE
Start and clean up keyboard listener

### DIFF
--- a/meeting_copilot.py
+++ b/meeting_copilot.py
@@ -218,6 +218,8 @@ def shutdown(reason="[shutdown]"):
     try:
         if listener is not None:
             listener.stop()
+            if listener != threading.current_thread():
+                listener.join(timeout=1.0)
     except Exception:
         pass
 
@@ -254,6 +256,10 @@ def main():
     t_stt = threading.Thread(target=stt_worker, daemon=True)
     t_capture.start()
     t_stt.start()
+
+    # Start keyboard listener for keypress detection
+    listener = keyboard.Listener(on_press=on_press)
+    listener.start()
 
     try:
         while not stop_program.is_set():


### PR DESCRIPTION
## Summary
- Start a pynput keyboard listener in `main()` before entering the main loop for keypress detection.
- Update `shutdown()` to stop and join the listener thread safely.

## Testing
- `python -m py_compile meeting_copilot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b96522559c8330ac2f67207788a731